### PR TITLE
Feature/content type abstraction

### DIFF
--- a/src/Structure/Content/ContentType.php
+++ b/src/Structure/Content/ContentType.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Define a structure for a generic type of content.
+ *
+ * This class will be extended by other OOPS-WP content types, such as PostType and Taxonomy,
+ * in order to help define the interface for creating new concrete instances of those entities.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-03-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Content;
+
+use WebDevStudios\OopsWP\Utility\Registerable;
+
+/**
+ * Class ContentType
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-03-01
+ */
+abstract class ContentType implements Registerable {
+	/**
+	 * Slug for the content.
+	 *
+	 * @var string
+	 * @since 2019-03-01
+	 */
+	protected $slug;
+
+	/**
+	 * Get the arguments for the content type.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-03-01
+	 */
+	abstract protected function get_args();
+
+	/**
+	 * Get the labels for the content type.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-03-01
+	 */
+	abstract protected function get_labels();
+}

--- a/src/Structure/Content/ContentType.php
+++ b/src/Structure/Content/ContentType.php
@@ -36,7 +36,15 @@ abstract class ContentType implements Registerable {
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 * @since  2019-03-01
 	 */
-	abstract protected function get_args();
+	abstract protected function get_args() : array;
+
+	/**
+	 * Get the default arguments for the content type.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-03-01
+	 */
+	abstract protected function get_default_args() : array;
 
 	/**
 	 * Get the labels for the content type.
@@ -44,5 +52,5 @@ abstract class ContentType implements Registerable {
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 * @since  2019-03-01
 	 */
-	abstract protected function get_labels();
+	abstract protected function get_labels() : array;
 }

--- a/src/Structure/Content/Taxonomy.php
+++ b/src/Structure/Content/Taxonomy.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Abstract class for taxonomy registration.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-03-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Content;
+
+/**
+ * Class Taxonomy
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-03-01
+ */
+abstract class Taxonomy extends ContentType {
+	/**
+	 * The object types this taxonomy supports.
+	 *
+	 * @var array
+	 * @since 2019-03-01
+	 */
+	protected $object_types;
+
+	/**
+	 * Register the taxonomy with WordPress.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws \Exception If taxonomy registration requirements are missing.
+	 * @return void
+	 * @since  2019-03-01
+	 */
+	public function register() {
+		if ( ! $this->meets_requirements() ) {
+			return;
+		}
+
+		register_taxonomy( $this->slug, (array) $this->object_types, array_merge( $this->get_default_args(), $this->get_args() ) );
+	}
+
+	/**
+	 * Check whether the taxonomy meets the requirements for registration.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws \Exception If taxonomy registration requirements are missing.
+	 * @since  2019-03-01
+	 * @return bool
+	 */
+	private function meets_requirements() {
+		if ( ! $this->slug ) {
+			throw new \Exception( __( 'You must give your taxonomy a slug in order to register it.', 'oops-wp' ) );
+		}
+
+		if ( ! $this->object_types ) {
+			throw new \Exception( __( 'You must declare which object types your taxonomy supports.', 'oops-wp' ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Taxonomy registration arguments.
+	 *
+	 * Extending classes can override this method to set their own arguments, overriding any defaults.
+	 *
+	 * @see    Taxonomy::get_default_args()
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-03-01
+	 * @return array
+	 */
+	protected function get_args() : array {
+		return [];
+	}
+
+	/**
+	 * Default Taxonomy registration arguments.
+	 *
+	 * Note: This class is protected to allow for third-party developers to extend this Taxonomy class into their
+	 * own Taxonomy class and set their own defaults. It's not intended for defaults to be set at the concrete
+	 * Taxonomy level.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-03-01
+	 * @return array
+	 */
+	protected function get_default_args() : array {
+		return [
+			'labels' => $this->get_labels(),
+		];
+	}
+}


### PR DESCRIPTION
This PR combines branches for #3 and #6 into one feature, which will introduce the Taxonomy abstract class to OOPS-WP. The work in here will support #7 as well, which has its own issue branch as it may not be compatible for a 0.2.0 release.

@phatsk and I spent some time pairing on this, discussing how a taxonomy would get registered within a plugin using this class, and what would be a sensible use case for providing defaults and what errors a developer should see if they're extending the class incorrectly. @jrfoell let me know if you have questions or additional feedback for this.

The develop branch will be the next release branch - I need to update the documentation, for which I'll open a separate issue.

Closes #3 
Closes #6 