### PR TITLE
Create abstract Plugin class and corresponding PluginInterface.

### DIFF
--- a/src/Structure/Plugin/Plugin.php
+++ b/src/Structure/Plugin/Plugin.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Defines a structure for a main WordPress plugin class file.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Plugin
+ * @since   2019-04-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Plugin;
+
+use WebDevStudios\OopsWP\Structure\ServiceRegistrar;
+
+/**
+ * Class Plugin
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Plugin
+ * @since   2019-04-01
+ */
+abstract class Plugin extends ServiceRegistrar implements PluginInterface {
+
+}

--- a/src/Structure/Plugin/PluginInterface.php
+++ b/src/Structure/Plugin/PluginInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Defines a contract for WordPress plugin's main class file registration.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Plugin
+ * @since 2019-04-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Plugin;
+
+use WebDevStudios\OopsWP\Utility\Runnable;
+
+/**
+ * Interface PluginInterface
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Plugin
+ * @since   2019-04-01
+ */
+interface PluginInterface extends Runnable {
+
+}


### PR DESCRIPTION
There's literally not much here since we have an empty abstract body and an empty interface body. What this change _does_ do, however, is enable our engineers, when creating their main plugin class, to extend the OopsWP `Plugin` class (as opposed its parent `ServiceRegistrar`). 

Each of the plugin's `Service`s can be added to the protected array, and we can start thinking about parts of the plugin as an independent service.