### PR TITLE
Issue/#2 add abstract data structure for shortcode registration

### DIFF
--- a/src/Structure/Content/Shortcode.php
+++ b/src/Structure/Content/Shortcode.php
@@ -49,5 +49,9 @@ abstract class Shortcode implements ShortcodeInterface {
 		if ( empty( $this->tag ) ) {
 			throw new \Exception( 'You must define the $tag property for your shortcode in ' . __CLASS__ );
 		}
+
+		if ( ! is_string( $this->tag ) ) {
+			throw new \Exception( 'The $tag property defined in your shortcode class ' . __CLASS__ . ' must be a string' );
+		}
 	}
 }

--- a/src/Structure/Content/Shortcode.php
+++ b/src/Structure/Content/Shortcode.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Defines a contract for shortcode registration.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-04-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Content;
+
+/**
+ * Class Shortcode
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-04-01
+ */
+abstract class Shortcode implements ShortcodeInterface {
+	/**
+	 * The shortcode tag.
+	 *
+	 * @var string
+	 * @since 2019-04-01
+	 */
+	protected $tag = '';
+
+	/**
+	 * Register the shortcode with WordPress.
+	 *
+	 * @since  2019-04-01
+	 * @throws \Exception If $tag is not set by the concrete class.
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 */
+	public function register() {
+		$this->validate_tag();
+
+		add_shortcode( $this->tag, [ $this, 'render' ] );
+	}
+
+	/**
+	 * Validate the provided shortcode tag.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws \Exception If the shortcode tag is not valid.
+	 * @since  2019-04-01
+	 */
+	private function validate_tag() {
+		if ( empty( $this->tag ) ) {
+			throw new \Exception( 'You must define the $tag property for your shortcode in ' . __CLASS__ );
+		}
+	}
+}

--- a/src/Structure/Content/ShortcodeInterface.php
+++ b/src/Structure/Content/ShortcodeInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Defines the contract for registering a shortcode with WordPress.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since 2019-04-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Content;
+
+use WebDevStudios\OopsWP\Utility\Registerable;
+use WebDevStudios\OopsWP\Utility\Renderable;
+
+/**
+ * Interface ShortcodeInterface
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-04-01
+ */
+interface ShortcodeInterface extends Registerable, Renderable {
+
+}

--- a/src/Utility/Renderable.php
+++ b/src/Utility/Renderable.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Define a contract for an object that can be rendered.
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Utility
+ * @since 2019-04-01
+ */
+
+namespace WebDevStudios\OopsWP\Utility;
+
+/**
+ * Interface Renderable
+ *
+ * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Utility
+ * @since   2019-04-01
+ */
+interface Renderable {
+	/**
+	 * Render a value from the object.
+	 *
+	 * @since  2019-04-01
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 */
+	public function render();
+}


### PR DESCRIPTION
Closes #2 

I _think_ this about covers everything that would be needed to set up a new `Shortcode` object. This PR includes a new interface, `Renderable`, which would be useful for any objects that need to render content to the screen. As far as I can recall, all shortcodes get rendered, so this should be a valid use case for this interface in the abstract class.

I also added some light validation to throw an exception if the shortcode isn't set or if it isn't a string, but we could probably extend that to ensure they actually adhere to WordPress's expectation.