### PR TITLE
Provides functions for introducing OO-focused Meta Boxes into OOPS-WP-based Plugins

### DIFF
--- a/src/Structure/Content/MetaBox.php
+++ b/src/Structure/Content/MetaBox.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Abstract class for meta box registration.
+ *
+ * @author  Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-05-01
+ */
+
+namespace WebDevStudios\OopsWP\Structure\Content;
+
+use Exception;
+use WebDevStudios\OopsWP\Utility\Registerable;
+
+/**
+ * Class MetaBox
+ *
+ * @author  Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Structure\Content
+ * @since   2019-05-01
+ */
+abstract class MetaBox extends ContentType implements Registerable {
+
+	/**
+	 * The slug used to identify this meta box.
+	 *
+	 * @var   string
+	 * @since 2019-05-01
+	 */
+	protected $slug;
+
+	/**
+	 * The title displayed at the top of the meta box.
+	 *
+	 * @var   string
+	 * @since 2019-05-01
+	 */
+	protected $title;
+
+	/**
+	 * The types of post in which this meta box should be displayed.
+	 *
+	 * @var   array
+	 * @since 2019-05-01
+	 */
+	protected $post_types;
+
+	/**
+	 * The context within the screen where the boxes should display.
+	 *
+	 * This is optional. The default value is 'side.'
+	 *
+	 * @var   string
+	 * @since 2019-05-01
+	 */
+	protected $context;
+
+	/**
+	 * The priority within the context where the boxes should show ('high', 'low', 'default').
+	 *
+	 * This is optional. The default value is 'default.'
+	 *
+	 * @var   string
+	 * @since 2019-05-01
+	 */
+	protected $priority;
+
+	/**
+	 * Data that should be set as the $args property of the meta box array
+	 * (which is the second parameter passed to your callback).
+	 *
+	 * This is optional. The default value is an empty array.
+	 *
+	 * @var   array
+	 * @since 2019-05-01
+	 */
+	protected $callback_args;
+
+	/**
+	 * Initializes the meta box with the specified arguments.
+	 *
+	 * @param string $slug                    Slug used to identify this meta box.
+	 * @param string $title                   Title displayed at the top of the meta box.
+	 * @param array  $post_types              Types of posts in which this meta box should be displayed.
+	 * @param string $context       Optional. Where the boxes should display.
+	 * @param string $priority      Optional. Where the boxes should show ('high', 'low', 'default').
+	 * @param array  $callback_args Optional. Data that should be set as the $args property of the meta box array.
+	 */
+	public function __construct(
+		string $slug,
+		string $title,
+		array $post_types,
+		string $context = 'side',
+		string $priority = 'default',
+		array $callback_args = []
+	) {
+		$this->slug          = $slug;
+		$this->title         = $title;
+		$this->post_types    = $post_types;
+		$this->context       = $context;
+		$this->priority      = $priority;
+		$this->callback_args = $callback_args;
+	}
+
+	/**
+	 * Register the metabox with WordPress.
+	 *
+	 * @author Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+	 * @throws Exception If the meta box requirements are missing.
+	 * @return void
+	 * @since  2019-05-01
+	 */
+	public function register() {
+		if ( ! $this->meets_requirements() ) {
+			return;
+		}
+
+		call_user_func_array(
+			'add_meta_box',
+			$this->get_default_args()
+		);
+	}
+
+	/**
+	 * Verifies the meta box has the requirements for proper registration with WordPress.
+	 *
+	 * @author Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+	 * @throws Exception If meta box registration requirements are missing.
+	 * @since  2019-05-01
+	 * @return bool
+	 */
+	private function meets_requirements() {
+		if ( ! $this->slug ) {
+			throw new Exception( __( 'You must give your meta box a slug to register it.', 'oops-wp' ) );
+		}
+
+		if ( empty( $this->post_types ) ) {
+			throw new Exception( __( 'You must specify at least one post type to display your meta box.', 'oops-wp' ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the arguments for the meta box.
+	 *
+	 * @author Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+	 * @return array
+	 * @since  2019-05-01
+	 */
+	protected function get_args() : array {
+		return $this->get_default_args();
+	}
+
+	/**
+	 * Generates the array of default arguments as defined by the constructor's arguments.
+	 * Invokes the subclasses 'render' function for displaying the contents of the meta box.
+	 *
+	 * @author Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+	 * @return array argumnets used to populate the properties of the meta box.
+	 * @since  2019-05-01
+	 */
+	protected function get_default_args(): array {
+		return [
+			'id'            => $this->slug,
+			'title'         => $this->title,
+			'callback'      => [ $this, 'render' ],
+			'screen'        => $this->post_types,
+			'context'       => $this->context,
+			'priority'      => $this->prioririty,
+			'callback_args' => $this->callback_args,
+		];
+	}
+
+	/**
+	 * Note: There are no labels for this content type. Provided by abstract
+	 * class implementation.
+	 *
+	 * @author Tom McFarlin <tom.mcfarlin@webdevstudios.com>
+	 * @return array
+	 * @since  2019-05-01
+	 */
+	protected function get_labels() : array {
+		return [];
+	}
+}

--- a/src/Structure/Content/MetaBox.php
+++ b/src/Structure/Content/MetaBox.php
@@ -167,7 +167,7 @@ abstract class MetaBox extends ContentType implements Registerable {
 			'callback'      => [ $this, 'render' ],
 			'screen'        => $this->post_types,
 			'context'       => $this->context,
-			'priority'      => $this->prioririty,
+			'priority'      => $this->priority,
 			'callback_args' => $this->callback_args,
 		];
 	}


### PR DESCRIPTION
## What's This Do?

This PR introduces `Structure\Content\MetaBox` into OOPS-WP. The goal is to make it easy to introduce meta boxes into OOPS-WP-powered plugins. 

This is specifically related to issue #16.

## How Does It Work?

To use this class, you need to do the following in your code (sample code provided later in this description, when necessary):

1. Define a `MetaBoxService`.
2. Instantiate the class that extends the `MetaBox` class in the `MetaBoxService`.
3. Add it to the plugin that extends the `ServiceRegistrar`.

The rest of the plugin should pick up what you need from there.

## Sample Code

### MetaBoxService

This class _must_ extend `Service`. Note that it's using `MetaBoxDemo` which is the concrete class that I'll demonstrate later in this comment for rendering the meta box.

Note that three values should be passed into the constructor with the other three being optional. This is documented in the `MetaBox` class itself.

```php
namespace WebDevStudios\OopsWP\Service;

use WebDevStudios\OopsWP\Structure\Service;
use WebDevStudios\OopsWP\Demo\MetaBoxDemo;

class MetaBoxService extends Service {

	private $content_types = [
		WebDevStudios\OopsWP\MetaBoxDemo::class,
	];

	public function register_hooks() {
		add_action( 'add_meta_boxes', [ $this, 'register_content_types' ] );
	}

	public function register_content_types() {
		( new MetaBoxDemo( 'example', 'Example', [ 'post' ] ) )->register();
	}
}
```

### MetaBoxDemo

This is a simple class. All it must do is:

1. `extend MetaBox`
2. and `implements Renderable`

From there, you can customize the `render` function as you need to display the contents of the meta box. This can be something as simple as the following:

```php
namespace WebDevStudios\OopsWP\Demo;

use WebDevStudios\OopsWP\Utility\Renderable;
use WebDevStudios\OopsWP\Structure\Content\MetaBox;

class MetaBoxDemo extends MetaBox implements Renderable {
	public function render() {
		echo 'Calling Render';
	}
}
```

Or it can be more involved where you have a template located in `Views` and want to render _that_ information to the screen:

```php
public function render() {
	include_once 'Views/meta-box.php';
}
```

## What About Saving Data?

To save data with your meta box, you'll need to update the `register_hooks` function in your `MetaBoxService` so that it also includes the following second line:

```php
public function register_hooks() {
	add_action( 'add_meta_boxes', [ $this, 'register_content_types' ] );
	add_action( 'save_post', [ $this, 'save' ] );
}
```

Note, however, that the `save` method as called above expects that the serialization functionality exists in the service when, in fact, it might make more sense to have it on the `MetaBoxDemo` itself. To do this, the `MetaBoxDemo` would need to be a property of the service and the function above would be redefined as:

```php
public function register_hooks() {
	add_action( 'add_meta_boxes', [ $this->meta_box, 'register_content_types' ] );
	add_action( 'save_post', [ $this->meta_box, 'save' ] );
}
```

But these can be for points of discussion.

## For Discussion

* Should there be a serialization interface provided for any class that wants to save data?
* Should we introduce services specifically for content types that we already have?
* Is it worth defining another `ContentType` so that we don't have to implement a method like `get_labels` for classes that don't require them?
