### PR TITLE
Issue/20 refactor editor block to simplify block registration

### DIFF
--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -50,28 +50,12 @@ abstract class EditorBlock implements EditorBlockInterface {
 	/**
 	 * Flag as to whether the block has front-end styles.
 	 *
+	 * Defaults to true. We will assume that most blocks will ship with a corresponding front-end stylesheet.
+	 *
 	 * @var bool
 	 * @since 2019-08-02
 	 */
-	protected $has_frontend_styles = false;
-
-	/**
-	 * The location of the block.
-	 *
-	 * Either plugin or theme.
-	 *
-	 * @var string
-	 */
-	private $content_dirname = 'plugins';
-
-	/**
-	 * The name of the package in which the block is contained.
-	 *
-	 * e.g., the plugin name or the theme name.
-	 *
-	 * @var string
-	 */
-	private $package_dirname;
+	protected $has_frontend_styles = true;
 
 	/**
 	 * The default relative path for locating block assets.
@@ -79,6 +63,20 @@ abstract class EditorBlock implements EditorBlockInterface {
 	 * @var string
 	 */
 	protected $relative_path = 'src/blocks';
+
+	/**
+	 * The directory within wp-content where the block is located.
+	 *
+	 * @var string
+	 */
+	private $wpcontent_dirname;
+
+	/**
+	 * The directory name of the plugin or theme.
+	 *
+	 * @var string
+	 */
+	private $package_dirname;
 
 	/**
 	 * Register the block with WordPress.

--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -44,7 +44,187 @@ abstract class EditorBlock implements EditorBlockInterface {
 
 		$this->register_script();
 		$this->register_style();
-		$this->register_type();
+
+		register_block_type( "{$this->name}", array_merge( $this->get_default_args(), $this->get_args() ) );
+	}
+
+	/**
+	 * Get the URL to an editor block asset.
+	 *
+	 * This method checks for the full path to the block assets and checks whether the provided asset
+	 * can be read at the given path. If it is,
+	 *
+	 * @param string $asset The asset for which to retrieve the URL.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-02-17
+	 * @return string
+	 * @throws \Exception If the class does not exist or the asset is not readable.
+	 */
+	public function get_asset_url( string $asset ) {
+		$full_assets_dir = $this->get_assets_path( $asset );
+		$asset_path      = $full_assets_dir . $asset;
+
+		if ( ! is_readable( $asset_path ) ) {
+			throw new \Exception( "Could not find requested asset at {$asset_path}." );
+		}
+
+		return trailingslashit( get_site_url() ) . str_replace( ABSPATH, '', $full_assets_dir ) . $asset;
+	}
+
+	/**
+	 * Get the root file path to this block's assets.
+	 *
+	 * @param string $asset The asset to look up.
+	 * @throws Exception If the file path value is not set or if the asset cannot be found.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 * @return string
+	 */
+	protected function get_assets_path( string $asset ): string {
+		if ( ! $this->file_path ) {
+			throw new Exception( 'File path not set on ' . get_called_class() );
+		}
+
+		$paths = $this->locate_valid_file_paths( $asset );
+
+		if ( empty( $paths ) ) {
+			throw new \Exception( "Could not find {$asset} at any expected file path." );
+		}
+
+		return $paths[0];
+	}
+
+	/**
+	 * Get the directory paths where block assets are stored for this given block.
+	 *
+	 * Note: this is completely customizable by an extending class.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 * @return array
+	 */
+	protected function get_valid_block_asset_directory_paths() : array {
+		return [
+			trailingslashit( $this->file_path . 'assets/blocks/' . $this->get_short_class_name() ),
+			trailingslashit( $this->file_path . 'blocks/' . $this->get_short_class_name() . '/assets' ),
+		];
+	}
+
+	/**
+	 * Get the short class name of this file.
+	 *
+	 * This class name is used to construct file paths to block assets.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 * @return string
+	 */
+	private function get_short_class_name() {
+		$block_class = explode( '\\', get_called_class() );
+
+		return array_pop( $block_class );
+	}
+
+	/**
+	 * Get the default arguments for block type registration.
+	 *
+	 * @return array
+	 * @since  2019-08-02
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 */
+	protected function get_default_args() : array {
+		return [
+			'editor_script' => "{$this->name}-js",
+			'editor_style'  => "{$this->name}-editor-css",
+		];
+	}
+
+	/**
+	 * Get additional arguments for block type registration.
+	 *
+	 * @since  2019-08-02
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @return array
+	 */
+	protected function get_args() : array {
+		return [];
+	}
+
+	/**
+	 * Get the default script dependencies for a registered block.
+	 *
+	 * By default, these script dependencies will be loaded with every concrete EditorBlock.
+	 * This method is set to protected to allow for override of the defaults by extending classes. For
+	 * those use cases, it is recommended to create an abstract class for your own implementation, then
+	 * have your concrete classes extend that new abstract.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 * @return array
+	 */
+	protected function get_default_block_scripts() {
+		return [
+			'wp-blocks',
+			'wp-element',
+		];
+	}
+
+	/**
+	 * Get additional script dependencies for the registered block.
+	 *
+	 * Anything that's not included in the defaults above can be added by the extending classes. This
+	 * might include scripts like wp-components, wp-i18n, and wp-editor, among others.
+	 *
+	 * @return array
+	 * @since  2019-08-02
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 */
+	protected function get_additional_block_scripts() : array {
+		return [];
+	}
+
+	/**
+	 * Register the JavaScript file that controls this EditorBlock.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws Exception If the JavaScript file cannot be found.
+	 * @since  2019-08-02
+	 */
+	protected function register_script() {
+		wp_register_script(
+			"{$this->name}-js",
+			$this->get_asset_url( 'block.js' ),
+			array_merge( $this->get_default_block_scripts(), $this->get_additional_block_scripts() )
+		);
+	}
+
+	/**
+	 * Get additional style dependencies for the registered block.
+	 *
+	 * Anything that's not included in the defaults can be added by the extending classes.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 */
+	protected function get_additional_block_styles() {
+		return [];
+	}
+
+	/**
+	 * Register the editor and front-end styles for rendering the block.
+	 *
+	 * @throws Exception If the style asset(s) cannot be found.
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-01-05
+	 */
+	protected function register_style() {
+		wp_register_style(
+			"{$this->name}-editor-css",
+			$this->get_asset_url( 'editor.css' ),
+			array_merge( [ 'wp-edit-block' ], $this->get_additional_block_styles() )
+		);
 	}
 
 	/**
@@ -67,119 +247,22 @@ abstract class EditorBlock implements EditorBlockInterface {
 	}
 
 	/**
-	 * Register the JavaScript file that controls this EditorBlock.
+	 * Locates the file paths that are valid for this block.
 	 *
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @throws Exception If the JavaScript file cannot be found.
+	 * @param string $asset The asset to locate.
+	 *
+	 * @return array
 	 * @since  2019-08-02
-	 * @return void
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 */
-	protected function register_script() {
-		wp_register_script(
-			"{$this->name}-js",
-			$this->get_asset_url( 'block.js' ),
-			array_merge( $this->get_default_block_scripts(), $this->get_additional_block_scripts() )
+	private function locate_valid_file_paths( string $asset ) {
+		return array_values(
+			array_filter(
+				$this->get_valid_block_asset_directory_paths(),
+				function ( $path ) use ( $asset ) {
+					return is_readable( $path . $asset );
+				}
+			)
 		);
 	}
-
-	/**
-	 *
-	 * @return array
-	 * @since  2019-08-02
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 */
-	protected function get_additional_block_scripts() : array {
-		return [];
-	}
-
-	/**
-	 * Get the URL to an editor block asset.
-	 *
-	 * This method checks for the full path to the block assets and checks whether the provided asset
-	 * can be read at the given path. If it is,
-	 *
-	 * @param string $asset The asset for which to retrieve the URL.
-	 *
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-02-17
-	 * @return string
-	 * @throws \Exception If the class does not exist or the asset is not readable.
-	 */
-	public function get_asset_url( string $asset ) {
-		$full_assets_dir = $this->get_assets_path();
-		$asset_path      = $full_assets_dir . $asset;
-
-		if ( ! is_readable( $asset_path ) ) {
-			throw new \Exception( "Could not find requested asset at {$asset_path}." );
-		}
-
-		return trailingslashit( get_site_url() ) . str_replace( ABSPATH, '', $full_assets_dir ) . $asset;
-	}
-
-	/**
-	 * Get the short class name of this file.
-	 *
-	 * This class name is used to construct file paths to block assets.
-	 *
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-08-02
-	 * @return string
-	 */
-	private function get_short_class_name() {
-		$block_class = explode( '\\', get_called_class() );
-
-		return array_pop( $block_class );
-	}
-
-	/**
-	 * Get the root file path to this block's assets.
-	 *
-	 * @throws Exception If the file path value is not set.
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-08-02
-	 * @return string
-	 */
-	protected function get_assets_path(): string {
-		if ( ! $this->file_path ) {
-			throw new Exception( 'File path not set on ' . get_called_class() );
-		}
-
-		return trailingslashit( $this->file_path . 'assets/blocks/' . $this->get_short_class_name() );
-	}
-
-	/**
-	 * Get the default script dependencies for a registered block.
-	 *
-	 * By default, these script dependencies will be loaded with every concrete EditorBlock.
-	 * This method is set to protected to allow for override of the defaults by extending classes. For
-	 * those use cases, it is recommended to create an abstract class for your own implementation, then
-	 * have your concrete classes extend that new abstract.
-	 *
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-08-02
-	 * @return array
-	 */
-	protected function get_default_block_scripts() {
-		return [
-			'wp-blocks',
-			'wp-i18n',
-			'wp-element',
-		];
-	}
-
-	/**
-	 * Register the editor and front-end styles for rendering the block.
-	 *
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-01-05
-	 */
-	abstract public function register_style();
-
-	/**
-	 * Register the type information for the block.
-	 *
-	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-01-04
-	 */
-	abstract public function register_type();
 }

--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -36,17 +36,34 @@ abstract class EditorBlock implements EditorBlockInterface {
 	 * Register the block with WordPress.
 	 *
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @throws Exception If block $name value is not defined.
+	 * @throws Exception If the block $name property is invalid.
 	 * @since  2019-01-04
 	 */
 	public function register() {
-		if ( ! is_string( $this->name ) ) {
-			throw new Exception( get_called_class() . ' must define a string value for $name.' );
-		}
+		$this->validate_name();
 
 		$this->register_script();
 		$this->register_style();
 		$this->register_type();
+	}
+
+	/**
+	 * Validate the name property of the block.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws Exception If the block name is invalid.
+	 * @since  2019-08-02
+	 */
+	private function validate_name() {
+		if ( ! is_string( $this->name ) ) {
+			throw new Exception( get_called_class() . ' must define a string value for $name.' );
+		}
+
+		$name_parts = explode( '/', $this->name );
+
+		if ( 2 !== count( $name_parts ) ) {
+			throw new Exception( get_called_class() . ' $name property is not properly namespaced.' );
+		}
 	}
 
 	/**

--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -2,6 +2,19 @@
 /**
  * Defines a contract for registering new editor blocks.
  *
+ * The purpose of this class is to provide a standardized model for declaring the location of editor block assets.
+ * The extending class should set a value for the $name property of the block, adhering to WordPress's namespacing
+ * convention for blocks (e.g., <vendor>/<block_name>). Additionally, the author of the block should create assets
+ * for the JavaScript entrypoint, the editor CSS and the front-end CSS with the following names:
+ * - index.js
+ * - editor.css
+ * - style.css
+ *
+ * By default, this class will look for these assets relative to the root directory of the plugin or theme, at
+ * /src/blocks/${name}/, where $name is the lowercase, hyphenated variant of the block name (excluding the vendor
+ * prefix). For example, if the $name property on your class is webdevstudios/my_awesome_block, your assets for this
+ * block should be in /src/blocks/my-awesome-block/.
+ *
  * @author  Jeremy Ward <jeremy.ward@webdevstudios.com>
  * @package WebDevStudios\OopsWP\Structure\Editor
  * @since   2019-01-04

--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -67,7 +67,36 @@ abstract class EditorBlock implements EditorBlockInterface {
 	}
 
 	/**
+	 * Register the JavaScript file that controls this EditorBlock.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws Exception If the JavaScript file cannot be found.
+	 * @since  2019-08-02
+	 * @return void
+	 */
+	protected function register_script() {
+		wp_register_script(
+			"{$this->name}-js",
+			$this->get_asset_url( 'block.js' ),
+			array_merge( $this->get_default_block_scripts(), $this->get_additional_block_scripts() )
+		);
+	}
+
+	/**
+	 *
+	 * @return array
+	 * @since  2019-08-02
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 */
+	protected function get_additional_block_scripts() : array {
+		return [];
+	}
+
+	/**
 	 * Get the URL to an editor block asset.
+	 *
+	 * This method checks for the full path to the block assets and checks whether the provided asset
+	 * can be read at the given path. If it is,
 	 *
 	 * @param string $asset The asset for which to retrieve the URL.
 	 *
@@ -77,26 +106,66 @@ abstract class EditorBlock implements EditorBlockInterface {
 	 * @throws \Exception If the class does not exist or the asset is not readable.
 	 */
 	public function get_asset_url( string $asset ) {
-		if ( ! $this->file_path ) {
-			$this->file_path = str_replace( ABSPATH, '', dirname( ( new \ReflectionClass( static::class ) )->getFileName(), 2 ) );
-		}
-
-		$asset_path = ABSPATH . $this->file_path . '/assets/' . $asset;
+		$full_assets_dir = $this->get_assets_path();
+		$asset_path      = $full_assets_dir . $asset;
 
 		if ( ! is_readable( $asset_path ) ) {
 			throw new \Exception( "Could not find requested asset at {$asset_path}." );
 		}
 
-		return trailingslashit( get_site_url() . "/{$this->file_path}/assets" ) . $asset;
+		return trailingslashit( get_site_url() ) . str_replace( ABSPATH, '', $full_assets_dir ) . $asset;
 	}
 
 	/**
-	 * Register the JavaScript assets that power the block.
+	 * Get the short class name of this file.
+	 *
+	 * This class name is used to construct file paths to block assets.
 	 *
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
-	 * @since  2019-01-04
+	 * @since  2019-08-02
+	 * @return string
 	 */
-	abstract public function register_script();
+	private function get_short_class_name() {
+		$block_class = explode( '\\', get_called_class() );
+
+		return array_pop( $block_class );
+	}
+
+	/**
+	 * Get the root file path to this block's assets.
+	 *
+	 * @throws Exception If the file path value is not set.
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 * @return string
+	 */
+	protected function get_assets_path(): string {
+		if ( ! $this->file_path ) {
+			throw new Exception( 'File path not set on ' . get_called_class() );
+		}
+
+		return trailingslashit( $this->file_path . 'assets/blocks/' . $this->get_short_class_name() );
+	}
+
+	/**
+	 * Get the default script dependencies for a registered block.
+	 *
+	 * By default, these script dependencies will be loaded with every concrete EditorBlock.
+	 * This method is set to protected to allow for override of the defaults by extending classes. For
+	 * those use cases, it is recommended to create an abstract class for your own implementation, then
+	 * have your concrete classes extend that new abstract.
+	 *
+	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @since  2019-08-02
+	 * @return array
+	 */
+	protected function get_default_block_scripts() {
+		return [
+			'wp-blocks',
+			'wp-i18n',
+			'wp-element',
+		];
+	}
 
 	/**
 	 * Register the editor and front-end styles for rendering the block.

--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -9,9 +9,8 @@
 
 namespace WebDevStudios\OopsWP\Structure\Editor;
 
-use WebDevStudios\OopsWP\Utility\AssetsLocator;
-use WebDevStudios\OopsWP\Utility\Registerable;
 use WebDevStudios\OopsWP\Utility\FilePathDependent;
+use \Exception;
 
 /**
  * Class EditorBlock
@@ -24,12 +23,27 @@ abstract class EditorBlock implements EditorBlockInterface {
 	use FilePathDependent;
 
 	/**
+	 * The full package name of the block.
+	 *
+	 * Examples: webdevstudios/custom-wysiwyg, webdevstudios-dynamic-block
+	 *
+	 * @var string
+	 * @since 2019-08-02
+	 */
+	protected $name;
+
+	/**
 	 * Register the block with WordPress.
 	 *
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
+	 * @throws Exception If block $name value is not defined.
 	 * @since  2019-01-04
 	 */
 	public function register() {
+		if ( ! is_string( $this->name ) ) {
+			throw new Exception( get_called_class() . ' must define a string value for $name.' );
+		}
+
 		$this->register_script();
 		$this->register_style();
 		$this->register_type();

--- a/src/Structure/Editor/EditorBlock.php
+++ b/src/Structure/Editor/EditorBlock.php
@@ -25,6 +25,7 @@ namespace WebDevStudios\OopsWP\Structure\Editor;
 use UnexpectedValueException;
 use WebDevStudios\OopsWP\Utility\FilePathDependent;
 use \Exception;
+use \ReflectionException;
 
 /**
  * Class EditorBlock


### PR DESCRIPTION
There's kind of a lot to unpack here. This refactor reduces the amount of PHP scaffolding necessary to register a custom Gutenberg block in WordPress. 

This class makes some assumptions that are potentially going to be particular to WDS, but it will expose an API via protected methods that extending classes could implement in order to have it work within their own setups.

### Assumption 1
Your custom blocks have the following structure from root within a plugin or theme (directory names in bold):

- **blocks**
-- **{BlockName}**
--- **assets**
---- index.js
---- editor.css
---- style.css (optional)
--- **src**
---- {BlockName}.php - this would extend the `EditorBlock` class, or an abstract extension of that class.

This would work for a stand-alone ES5 implementation of a block structure. If individual block assets are being compiled, then we're also assuming this structure:

- **assets**
-- **dist**
--- **{BlockName}**
---- index.js

Block assets should be compiled, using whatever bundling app of your choice, into standalone directories for each blocks. The BlockName directories should be CamelCase and mirror the PSR-4 style classnames of the PHP files.

### Assumption 2
By default, all blocks are registering an index.js file for controlling the block and an editor.css file for styling the block in the admin. Extending classes can set the `$has_frontend_styles` flag to `true` if they also have a `style.css` stylesheet for front-end rendering.

## Additional Details
Generally, this class is very extensible and requires only a namespaced `$name` value in order to register it. WordPress will throw exceptions if the name value is missing or is not correctly namespaced in the fashion that it expects (e.g., <vendor-name>/<block-name>). Customization happens by way of the `get_args` method (which allows further customization for which properties get passed to `register_block_type`), `get_additional_block_scripts` (which allows  further customization for which script dependencies a block relies, such as wp-editor, wp-i18n, wp-components, and so on), and `get_additional_block_styles`, which works the same way, except for styles instead of scripts (e.g., the `editor_style` value has a dependency on `wp-edit-block`, but there may be other scripts needed here or on the front-end as well.

The vast majority of the methods in the class are protected, so extending classes can modify elements of block registration to suit their needs. This does expose a significant API for the `EditorBlock` object, and that is one element I'd like to discuss - how extensible this object should be. Given the open-source nature of this project and that WDS has intended uses that may not mirror the broader community, I'd like to ensure that we're being good stewards of this project and being cognizant of when we're introducing new APIs that we might subsequently break in the future (related: this change very much breaks backward compatibility with the previous EditorBlock implementations).