### PR TITLE
Change visibility of init_services method from private to protected

### DIFF
--- a/src/Structure/ServiceRegistrar.php
+++ b/src/Structure/ServiceRegistrar.php
@@ -67,7 +67,7 @@ abstract class ServiceRegistrar implements Runnable {
 	 * @since  2019-04-01
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 */
-	private function init_services() {
+	protected function init_services() {
 		$objects = array_map( function ( $service_class ) {
 			return [
 				'namespace' => $service_class,


### PR DESCRIPTION
Closes #23.

Merging this and bumping to 0.2.1. This change will enable engineers to override the `init_services` method in classes which extend `Plugin`. 