### PR TITLE
Wrap example require_once in file_exists() check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ available for you to use. In order to make those structures available
 to WordPress, you'll need to require the Composer-generated autoload file:
 
 ```
-require_once __DIR__ . '/vendor/autoload.php';
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
 ```
 
 ### A Caveat


### PR DESCRIPTION
If the plugin is being loaded as a dependency of something larger (e.g.
the project is loading plugins via Composer), the vendor directory may
not be local to this plugin. We don't want to throw a fatal error if
this is the case, so we check for the existance of the file first.

Fixes #28