### PR TITLE
Wrap example require_once in is_readable() check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ available for you to use. In order to make those structures available
 to WordPress, you'll need to require the Composer-generated autoload file:
 
 ```
-require_once __DIR__ . '/vendor/autoload.php';
+if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
 ```
 
 ### A Caveat

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 ```
 
+**Note:** Details on why we include the `is_readable()` check is available [in the wiki](https://github.com/WebDevStudios/oops-wp/wiki/Why-wrap-require-autoloader-in-a-is_readable%28%29-check%3F).
+
 ### A Caveat
 WordPress isn't designed to be compatible with Composer, and many plugins
 and themes may wind up using the same libraries. This library is


### PR DESCRIPTION
If the plugin is being loaded as a dependency of something larger (e.g.
the project is loading plugins via Composer), the vendor directory may
not be local to this plugin. We don't want to throw a fatal error if
this is the case, so we check the file exists and is readable first.

Fixes #28