### PR TITLE
Issue/17 throw slug exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+- Introduces `RequirementNotMetException` for throwing when a class' requirements are not met
+- Updates `PostType` class to throw exception when `$slug` is missing
+
 ## 0.3.0
 - Introduce Menu structure for registering custom menus.
 - Fix issue with Shortcode structure that prevented processing of attributes and content.

--- a/src/Exception/RequirementNotMetException.php
+++ b/src/Exception/RequirementNotMetException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Exception to indicate requirements for an object have not
+ * been met.
+ *
+ * @author  Evan Hildreth <evan.hildreth@webdevstudios.com>
+ * @package WebDevStudios\OopsWP\Exception
+ */
+
+namespace WebDevStudios\OopsWP\Exception;
+
+/**
+ * Class RequirementNotMetException
+ * 
+ * For use when a subclass is missing a required piece of
+ * information and cannot perform its function. For example,
+ * failing to provide a slug for a custom post type.
+ *
+ * @package WebDevStudios\OopsWP\Exception
+ * @since   2020-02-28
+ */
+class RequirementNotMetException extends \Exception
+{
+    /**
+		 * Construct a RequirementNotMetException.
+		 *
+		 * @param string     $message Required message describing the requirement
+		 * @param int        $code Defaults to 0
+		 * @param \Exception $previous Defaults to null
+		 */
+    public function __construct($message, $code = 0, Exception $previous = null) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Structure/Content/PostType.php
+++ b/src/Structure/Content/PostType.php
@@ -26,11 +26,26 @@ abstract class PostType extends ContentType {
 	/**
 	 * Callback to register the post type with WordPress.
 	 *
-	 * @TODO  Add exception if slug is null. Extending classes should be defining their own.
+	 * @throws \Exception If post type registration requirements are missing.
 	 * @since 0.1.0
 	 */
 	public function register() {
+		$this->check_requirements();
+
 		register_post_type( $this->slug, array_merge( $this->get_default_args(), $this->get_args() ) );
+	}
+
+	/**
+	 * Check whether the post type meets the requirements for registration. Throws exception if not.
+	 *
+	 * @author Evan Hildreth <evan.hildreth@webdevstudios.com>
+	 * @throws \Exception If post type registration requirements are missing.
+	 * @since  2020-02-28
+	 */
+	private function check_requirements() {
+		if ( ! $this->slug ) {
+			throw new \Exception( __( 'You must give your post type a slug in order to register it.', 'oops-wp' ) );
+		}
 	}
 
 	/**

--- a/src/Structure/Content/PostType.php
+++ b/src/Structure/Content/PostType.php
@@ -8,6 +8,8 @@
 
 namespace WebDevStudios\OopsWP\Structure\Content;
 
+use WebDevStudios\OopsWP\Exception\RequirementNotMetException;
+
 /**
  * Class PostType
  *
@@ -26,7 +28,7 @@ abstract class PostType extends ContentType {
 	/**
 	 * Callback to register the post type with WordPress.
 	 *
-	 * @throws \Exception If post type registration requirements are missing.
+	 * @throws RequirementNotMetException If post type registration requirements are missing.
 	 * @since 0.1.0
 	 */
 	public function register() {
@@ -39,12 +41,12 @@ abstract class PostType extends ContentType {
 	 * Check whether the post type meets the requirements for registration. Throws exception if not.
 	 *
 	 * @author Evan Hildreth <evan.hildreth@webdevstudios.com>
-	 * @throws \Exception If post type registration requirements are missing.
+	 * @throws RequirementNotMetException If post type registration requirements are missing.
 	 * @since  2020-02-28
 	 */
 	private function check_requirements() {
 		if ( ! $this->slug ) {
-			throw new \Exception( __( 'You must give your post type a slug in order to register it.', 'oops-wp' ) );
+			throw new RequirementNotMetException( __( 'You must give your post type a slug in order to register it.', 'oops-wp' ) );
 		}
 	}
 


### PR DESCRIPTION
Closes #17 

### DESCRIPTION ###

- Added a new `RequirementsNotMetException`
- Throws said exception in `PostType` class to alert when `$slug` is not present

### SCREENSHOTS ###

<img width="864" alt="image" src="https://user-images.githubusercontent.com/1427716/75578341-a799e700-5a31-11ea-9de3-09e78e9e8a43.png">

### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [ ] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY ###

Use the OOPS-WP Demo plugin and modify `src/Content/PostType/Game.php` to not have a slug.