### PR TITLE
Update composer files to add PHP 8 support and other minor adjustments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.3.1
+- Update requirements to support PHP 8.
+
 ## 0.3.0
 - Introduce Menu structure for registering custom menus.
 - Fix issue with Shortcode structure that prevented processing of attributes and content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 0.3.1
+## 1.0.0
 - Update requirements to support PHP 8.
 
 ## 0.3.0

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "authors": [
         {
             "name": "Jeremy Ward",
-            "email": "jeremy.ward@webdevstudios.com",
-            "role": "Senior Backend Engineer"
+            "email": "jeremy@jmichaelward.com",
+            "role": "Software Engineer"
         }
     ],
     "license": "GPL-2.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7"
+        "php": "^7 || ^8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6f20399ed2319d76f713a1b3ee5d1c6",
+    "content-hash": "630441e74486a3c0c9ba170cdecc1c09",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,7 +13,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7"
+        "php": "^7 || ^8"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Structure/Content/ShortcodeInterface.php
+++ b/src/Structure/Content/ShortcodeInterface.php
@@ -32,6 +32,8 @@ interface ShortcodeInterface extends Registerable, Renderable {
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 * @since  2020-01-31
 	 * @see    Shortcode::process_output() for example default implementation.
+	 *
+	 * @return string
 	 */
 	public function process_output( $atts, string $content = '' ) : string;
 

--- a/src/Structure/ServiceRegistrar.php
+++ b/src/Structure/ServiceRegistrar.php
@@ -86,7 +86,7 @@ abstract class ServiceRegistrar implements Runnable {
 	 */
 	private function set_file_path_on_services() {
 		foreach ( array_filter( $this->services, [ $this, 'service_uses_file_path' ] ) as $service ) {
-			/* @var $service FilePathDependent FilePathDependent service. */
+			/* @var FilePathDependent $service FilePathDependent service. */
 			$service->set_file_path( $this->file_path );
 		}
 	}


### PR DESCRIPTION
Hey gang!

I've made some extremely minor adjustments in this PR, and was hoping one of you would be able to review and potentially merge and tag this change. The PR contains the following changes:

1. Updates the composer.json and composer.lock file to include PHP 8 in the set of requirements for the library, making it installable on sites using PHP 8.
2. Updates my author contact information. WDS maintainers could consider adding their own contact info, or a general author role, to this authors block.
3. Added a missing return PHP doc to a method in the ShortcodeInterface interface.
4. Changed the order of the comment typehint due to warnings thrown in PhpStorm.

The most important change in this PR is the first one, but I think they're all relevant. Assuming this looks good, after merge, someone at WDS will need to tag this release, which should automatically make it available via Packagist.org. Please feel free to reach out to me with any questions - I'd be more than happy to help facilitate the process. My contact info is, well, in this PR. 😛 